### PR TITLE
corr card image

### DIFF
--- a/src/js/obj-normalize/index.js
+++ b/src/js/obj-normalize/index.js
@@ -52,42 +52,49 @@ function objCardNormalize(objItem) {
   //Короткий опис новини
   dataCard.abstract = objItem.abstract;
 
-  //нема ради, отака страшна перевірка:)
-  if (objItem.media)
-    if (objItem.media.length)
-      if (objItem.media[0]['media-metadata'])
-        if (objItem.media[0]['media-metadata'].length) {
-          //пошук оптимальної картинки
-          const objImage = searchObjImageForCard(
-            objItem.media[0]['media-metadata']
-          );
+  searchPathImage(objItem);
 
-          if (!/static01.nyt.com/i.test(objImage.url)) {
-            objImage.url = baseUrl + objImage.url;
+  function searchPathImage(objItem) {
+    //нема ради, отака страшна перевірка:)
+    if (objItem.media)
+      if (objItem.media.length)
+        if (objItem.media[0]['media-metadata'])
+          if (objItem.media[0]['media-metadata'].length) {
+            //пошук оптимальної картинки
+            const objImage = searchObjImageForCard(
+              objItem.media[0]['media-metadata']
+            );
+
+            if (!/static01.nyt.com/i.test(objImage.url)) {
+              objImage.url = baseUrl + objImage.url;
+            }
+
+            // src картинки
+            dataCard.imageUrl = objImage.url;
+            return;
           }
 
-          // src картинки
-          dataCard.imageUrl = objImage.url;
-        } else {
-          if (objItem.multimedia)
-            if (objItem.multimedia.length) {
-              //пошук оптимальної картинки
-              const objImage = searchObjImageForCard(objItem.multimedia);
+    if (objItem.multimedia)
+      if (objItem.multimedia.length) {
+        //пошук оптимальної картинки
+        const objImage = searchObjImageForCard(objItem.multimedia);
 
-              if (!/static01.nyt.com/i.test(objImage.url)) {
-                objImage.url = baseUrl + objImage.url;
-              }
-
-              // src картинки
-              dataCard.imageUrl = objImage.url;
-
-              // alt картинки
-              dataCard.imageAlt = objImage.caption;
-            } else {
-              // if("загубилась картинка") return буде:)
-              dataCard.imageUrl = defaultImageUrl;
-            }
+        if (!/static01.nyt.com/i.test(objImage.url)) {
+          objImage.url = baseUrl + objImage.url;
         }
+
+        // src картинки
+        dataCard.imageUrl = objImage.url;
+
+        // alt картинки
+        dataCard.imageAlt = objImage.caption;
+        return;
+      }
+
+    // if("загубилась картинка") return буде:)
+    dataCard.imageUrl = defaultImageUrl;
+    return;
+  }
 
   dataCard.url = objItem.url || objItem.web_url;
 

--- a/src/sass/layouts/_card.scss
+++ b/src/sass/layouts/_card.scss
@@ -165,7 +165,8 @@
 
   &__date {
     position: absolute;
-    bottom: 2px;
+    bottom: 4px;
+    left: 5px;
     font-family: var(--font-family-main);
     font-style: normal;
     font-weight: 400;
@@ -182,8 +183,8 @@
 
   &__read {
     position: absolute;
-    bottom: 2px;
-    right: 2px;
+    bottom: 4px;
+    right: 5px;
     font-family: var(--font-family-main);
     font-style: normal;
     font-weight: 400;


### PR DESCRIPTION
підредагував obj-normalize, не стягувало дефолтну картинку за її відсутності у новині + corr _card.scss